### PR TITLE
docs: Adds Resources Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [Projects](#projects)
   - [Open Source](#open-source)
   - [App Releases](#app-releases)
+- [Resources](#resources)
 - [Non-English Content](#non-english-content)
 
 ## Articles & Tutorials
@@ -226,6 +227,10 @@ By Tommy Buonomo ([Frenchie Games](https://frenchiegames.app/#/))
 #### Tower Defense
 
 - Xtrike - [Android](https://play.google.com/store/apps/details?id=online.xtrike.xtrike) - An awesome strategic tower defense game. Build your battle units and destroy enemies. By [White Wood City](http://www.xtrike.online/)
+
+## Resources
+
+- [Game UI Database](https://www.gameuidatabase.com/index.php) - The ultimate screen reference Tool for game interface designers.  Explore over 500 games and 19,000 individual images, and filter by screen type, material, layout, texture, shapes, patterns, genre and more!
 
 ## Non-English Content
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ to get their code to run with any up-to-date version of Flame.
 - [flame_gamepad](https://github.com/flame-engine/flame_gamepad) - Flutter Gamepad Support.
 - [flame_geom](https://github.com/flame-engine/flame_geom) - Complement Flame with APIs for handling shapes and geometric operations.
 - [flame_scrolling_sprite](https://github.com/flame-engine/flame_scrolling_sprite) - Easy to use sprites that repeats itself on an area.
-- [play_games](https://github.com/flame-engine/play_games) - A simple wrapper on top of Google Play Games Services (GPGS), including auth, achievement, and more.
 
 ### Community
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ By Tommy Buonomo ([Frenchie Games](https://frenchiegames.app/#/))
 
 ## Resources
 
-- [Game UI Database](https://www.gameuidatabase.com/) - The ultimate screen reference Tool for game interface designers.  Explore over 500 games and 19,000 individual images, and filter by screen type, material, layout, texture, shapes, patterns, genre and more!
+- [Game UI Database](https://www.gameuidatabase.com/) - The ultimate screen reference tool for game interface designers. Explore over 500 games and 19,000 individual images, and filter by screen type, material, layout, texture, shapes, patterns, genres and more!
 
 ## Non-English Content
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ By Tommy Buonomo ([Frenchie Games](https://frenchiegames.app/#/))
 
 ## Resources
 
-- [Game UI Database](https://www.gameuidatabase.com/index.php) - The ultimate screen reference Tool for game interface designers.  Explore over 500 games and 19,000 individual images, and filter by screen type, material, layout, texture, shapes, patterns, genre and more!
+- [Game UI Database](https://www.gameuidatabase.com/) - The ultimate screen reference Tool for game interface designers.  Explore over 500 games and 19,000 individual images, and filter by screen type, material, layout, texture, shapes, patterns, genre and more!
 
 ## Non-English Content
 


### PR DESCRIPTION
Stemming from a conversation in Discord with @st-pasha and @erickzanardo.  I have added a resources section and added the game ui database.

https://discord.com/channels/509714518008528896/833768206396555334/1035521724097249280

Also removes play_games link as per discussion with Spydon.
