### PR TITLE
Add Meccha Chameleon Art fan atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,3 +301,8 @@ By Tommy Buonomo ([Frenchie Games](https://frenchiegames.app/#/))
 [2]: <https://www.yayocode.com> 'YayoCode'
 [3]: <https://www.dong.digital> 'Dong Digital'
 [4]: <https://www.coconutisland.app> 'Coconut Island Apps'
+
+## Community Resource Additions
+
+<!-- Added 2026-06-24 by zlc000190 -->
+- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon (paint-based hide-and-seek Steam game). 50+ hiding spot atlas with color analysis, bilingual (EN/中文). GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot


### PR DESCRIPTION
## Community Resource

- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon, a paint-based hide-and-seek Steam game. 50+ hiding spot atlas with color analysis, bilingual (EN/中文).
- GitHub: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot

Fan-made, unofficial. Meccha Chameleon is © LEMORION.