### PR TITLE
Add flame_fuse to the libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - [bonfire](https://github.com/RafaelBarbosatec/bonfire) - RPG maker. By [rafaelbarbosatec](https://github.com/RafaelBarbosatec)
 - [flame_texturepacker](https://github.com/Brixto/flame_texturepacker) - Import spritesheets from TexturePacker. By [Brixto](https://github.com/Brixto)
 - [leap](https://github.com/kurtome/leap) - An opinionated toolkit for creating 2D platformers. By [kurtome](https://github.com/kurtome)
+- [fuse](https://github.com/misha/flame_fuse) - Behavior composition with hooks for Flame components. By [Misha](https://github.com/misha)
 
 ## Projects
 


### PR DESCRIPTION
`flame_fuse` is a library that transforms Flame's class API into a functional one. I have used it for my games for years now, keeping pace with changes to the Flame API.